### PR TITLE
Publish on specified Exchange.

### DIFF
--- a/notabene/kombu_driver.py
+++ b/notabene/kombu_driver.py
@@ -90,7 +90,7 @@ class Worker(kombu.mixins.ConsumerMixin):
 def send_notification(message, routing_key, connection, exchange):
     with kombu.pools.producers[connection].acquire(block=True) as producer:
          kombu.common.maybe_declare(exchange, producer.channel)
-         producer.publish(message, routing_key)
+         producer.publish(message, routing_key=routing_key, exchange=exchange)
 
 
 def create_connection(hostname, port, userid, password, transport,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = notabene
-version = 0.1
+version = 0.2
 author = Dark Secret Software Inc.
 author-email = admin@darksecretsoftware.com
 summary = Simple AMQP consumer / publisher for OpenStack notifications


### PR DESCRIPTION
publish() can optionally take an exchange name. But if not provided,
it will publish on the default "nameless" exchange. The semantics
for the nameless exchange are different for routing:

"The exchange parameter is the the name of the exchange.
The empty string denotes the default or nameless exchange:
messages are routed to the queue with the name
specified by routing_key, if it exists."
