### PR TITLE
Handle serialization of datetimes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-anyjson
 kombu

--- a/tests/test_kombu.py
+++ b/tests/test_kombu.py
@@ -4,7 +4,7 @@
 from contextlib import nested
 import unittest
 
-import anyjson
+import json
 import mock
 from notabene import kombu_driver
 
@@ -53,7 +53,7 @@ class TestKombuDriver(unittest.TestCase):
         w = self._create_worker(callback, None, "deployment", None)
         message = mock.Mock()
         message.delivery_info = {'routing_key': "the key"}
-        message.body = anyjson.dumps({'payload': 123})
+        message.body = json.dumps({'payload': 123})
         w._process(message)
 
         self.assertTrue(callback.on_event.called_once)


### PR DESCRIPTION
Since json dosen't have a native datetime type, we stringify
datetimes (str() on a python datetime is an acceptable ISO8601 date)
on serialization.

This will prevent the json serialization from throwing TypeError
on data structures containing dates, and keep clients from having
to dig through nested structures to catch and str() all dates.
